### PR TITLE
13 trading bin config

### DIFF
--- a/quantlib/Cargo.toml
+++ b/quantlib/Cargo.toml
@@ -14,3 +14,4 @@ tokio = { version = "1", features = ["full"] }
 chrono = { version = "0.4", features = ["serde"] }
 log = "~0.4"
 log4rs = "~1"
+rand = "0.8.5"

--- a/quantlib/src/models/alpha_model.rs
+++ b/quantlib/src/models/alpha_model.rs
@@ -1,61 +1,103 @@
 use rand::Rng;
 
-use crate::models::TradingSignal;
 use crate::oanda::objects::Price;
+use crate::{models::TradingSignal, util::TradingConfig};
 use serde::{Deserialize, Serialize};
 
 pub trait AlphaModel {
     fn tick(&mut self, price: &Price) -> Result<Option<TradingSignal>, Box<dyn std::error::Error>>;
+    fn from_config(config: &TradingConfig) -> Result<Self, Box<dyn std::error::Error>>
+    where
+        Self: Sized;
 }
 
+pub enum AlphaModels {
+    Random(RandomStrategy),
+    ExponentialMovingAverage(ExponentialMovingAverage),
+}
+
+impl AlphaModel for AlphaModels {
+    fn tick(&mut self, price: &Price) -> Result<Option<TradingSignal>, Box<dyn std::error::Error>> {
+        match self {
+            AlphaModels::Random(strategy) => strategy.tick(price),
+            AlphaModels::ExponentialMovingAverage(strategy) => strategy.tick(price),
+        }
+    }
+
+    fn from_config(config: &TradingConfig) -> Result<Self, Box<dyn std::error::Error>> {
+        println!("{:?}", config);
+        match config.model.as_str() {
+            "random" => {
+                let rng = rand::thread_rng();
+                let strategy = RandomStrategy {
+                    buy_threshold: config.model_config["buyThreshold"].as_f64().unwrap(),
+                    sell_threshold: config.model_config["sellThreshold"].as_f64().unwrap(),
+                    rng,
+                };
+                Ok(AlphaModels::Random(strategy))
+            }
+            "ema" => {
+                let slow_ma_weight = config.model_config["slowWeight"].as_f64().unwrap();
+                let fast_ma_weight = config.model_config["fastWeight"].as_f64().unwrap();
+                let strategy = ExponentialMovingAverage::new(slow_ma_weight, fast_ma_weight);
+                Ok(AlphaModels::ExponentialMovingAverage(strategy))
+            }
+            _ => panic!("Unknown model: {}", config.model),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ExponentialMovingAverage {
-    instrument: String,
+    #[serde(rename = "slowWeight")]
+    slow_ma_weight: f64,
+    #[serde(rename = "fastWeight")]
+    fast_ma_weight: f64,
 
-    slow_ma_weight: f32,
-    fast_ma_weight: f32,
-
-    slow_ma: f32,
-    fast_ma: f32,
+    #[serde(skip)]
+    slow_ma: f64,
+    #[serde(skip)]
+    fast_ma: f64,
 }
 
 impl ExponentialMovingAverage {
-    pub fn new(instrument: String, slow_ma_weight: f32, fast_ma_weight: f32) -> Self {
+    pub fn new(slow_ma_weight: f64, fast_ma_weight: f64) -> Self {
         ExponentialMovingAverage {
-            instrument,
             slow_ma_weight,
             fast_ma_weight,
             slow_ma: -1.0,
             fast_ma: -1.0,
         }
     }
-}
 
-impl AlphaModel for ExponentialMovingAverage {
-    fn tick(&mut self, price: &Price) -> Result<Option<TradingSignal>, Box<dyn std::error::Error>> {
+    pub fn tick(
+        &mut self,
+        price: &Price,
+    ) -> Result<Option<TradingSignal>, Box<dyn std::error::Error>> {
         let mut signal = None;
 
         // If we don't have a slow or fast moving average yet, set them to the current price
         if self.slow_ma < 0.0 || self.fast_ma < 0.0 {
-            self.fast_ma = price.ask;
-            self.slow_ma = price.ask;
+            self.fast_ma = price.ask as f64;
+            self.slow_ma = price.ask as f64;
             return Ok(None);
         }
 
         // Calculate the new moving averages
         let new_slow_ma =
-            self.slow_ma_weight * price.ask + (1.0 - self.slow_ma_weight) * self.slow_ma;
+            self.slow_ma_weight * price.ask as f64 + (1.0 - self.slow_ma_weight) * self.slow_ma;
         let new_fast_ma =
-            self.fast_ma_weight * price.ask + (1.0 - self.fast_ma_weight) * self.fast_ma;
+            self.fast_ma_weight * price.ask as f64 + (1.0 - self.fast_ma_weight) * self.fast_ma;
 
         // If the fast moving average crosses above the slow moving average, buy
         if new_fast_ma > new_slow_ma && self.fast_ma < self.slow_ma {
             signal = Some(TradingSignal {
-                instrument: self.instrument.clone(),
+                instrument: price.instrument.clone(),
                 forecast: 1.0,
             });
         } else if new_fast_ma < new_slow_ma && self.fast_ma > self.slow_ma {
             signal = Some(TradingSignal {
-                instrument: self.instrument.clone(),
+                instrument: price.instrument.clone(),
                 forecast: -1.0,
             });
         }
@@ -66,66 +108,9 @@ impl AlphaModel for ExponentialMovingAverage {
     }
 }
 
-pub struct SimpleMovingAverage {
-    instrument: String,
-    period: usize,
-    prices: Vec<f32>,
-}
-
-impl SimpleMovingAverage {
-    pub fn new(instrument: String, period: usize) -> Self {
-        SimpleMovingAverage {
-            instrument,
-            period,
-            prices: Vec::new(),
-        }
-    }
-}
-
-impl AlphaModel for SimpleMovingAverage {
-    fn tick(&mut self, price: &Price) -> Result<Option<TradingSignal>, Box<dyn std::error::Error>> {
-        let signal;
-
-        // Add the current price to the list of prices
-        self.prices.push(price.ask);
-
-        // If we don't have enough prices yet, return None
-        if self.prices.len() < self.period {
-            return Ok(None);
-        }
-
-        // If we have too many prices, remove the oldest price
-        if self.prices.len() > self.period {
-            self.prices.remove(0);
-        }
-
-        // Calculate the average of the prices
-        let mut sum = 0.0;
-        for price in &self.prices {
-            sum += price;
-        }
-        let average = sum / self.prices.len() as f32;
-
-        // If the current price is above the average, buy
-        if price.ask > average {
-            signal = Some(TradingSignal {
-                instrument: self.instrument.clone(),
-                forecast: 1.0,
-            });
-        } else {
-            signal = Some(TradingSignal {
-                instrument: self.instrument.clone(),
-                forecast: -1.0,
-            });
-        }
-
-        Ok(signal)
-    }
-}
-
 // A simple weighted consensus model that takes the average of all the signals of a collection of models
 pub struct WeightedConsensus {
-    models: Vec<Box<dyn AlphaModel>>,
+    models: Vec<AlphaModels>,
     weights: Vec<f64>,
 }
 
@@ -137,15 +122,17 @@ impl WeightedConsensus {
         }
     }
 
-    pub fn add_model(mut self, model: Box<dyn AlphaModel>, weight: f64) -> Self {
+    pub fn add_model(mut self, model: AlphaModels, weight: f64) -> Self {
         self.models.push(model);
         self.weights.push(weight);
         self
     }
-}
 
-impl AlphaModel for WeightedConsensus {
-    fn tick(&mut self, price: &Price) -> Result<Option<TradingSignal>, Box<dyn std::error::Error>> {
+    // TODO: Remove the clone() calls; there must be a better way (should instrument be included in the TradingSignal? Maybe whatever is calling the model should know the instruments since models are agnostic to instruments?)
+    pub fn tick(
+        &mut self,
+        price: &Price,
+    ) -> Result<Option<TradingSignal>, Box<dyn std::error::Error>> {
         // Iterate over all the models and get their signals
         let mut signals = Vec::new();
         for model in &mut self.models {
@@ -180,14 +167,21 @@ impl AlphaModel for WeightedConsensus {
 }
 
 // A simple random strategy that randomly buys or sells based on configurable thresholds
+#[derive(Serialize, Deserialize, Debug)]
 pub struct RandomStrategy {
+    #[serde(rename = "buyThreshold")]
     pub buy_threshold: f64,
+    #[serde(rename = "sellThreshold")]
     pub sell_threshold: f64,
+    #[serde(skip)]
     pub rng: rand::rngs::ThreadRng,
 }
 
-impl AlphaModel for RandomStrategy {
-    fn tick(&mut self, price: &Price) -> Result<Option<TradingSignal>, Box<dyn std::error::Error>> {
+impl RandomStrategy {
+    pub fn tick(
+        &mut self,
+        price: &Price,
+    ) -> Result<Option<TradingSignal>, Box<dyn std::error::Error>> {
         let signal;
         let random: f64 = self.rng.gen();
 
@@ -206,49 +200,5 @@ impl AlphaModel for RandomStrategy {
         }
 
         Ok(signal)
-    }
-}
-
-impl RandomStrategy {
-    // Create a new RandomStrategy with the given buy and sell thresholds from a JSON configuration
-    // TODO: Add proper error handling
-    pub fn from_config(config: &serde_json::Value) -> Self {
-        let buy_threshold = config["buy_threshold"].as_f64().unwrap();
-        let sell_threshold = config["sell_threshold"].as_f64().unwrap();
-        if buy_threshold + sell_threshold > 1.0 {
-            panic!("Buy and sell thresholds must sum to less than 1.0");
-        }
-        RandomStrategy {
-            buy_threshold,
-            sell_threshold,
-            rng: rand::thread_rng(),
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct RandomStrategyConfig {
-    #[serde(rename = "buyThreshold")]
-    buy_threshold: f64,
-    #[serde(rename = "sellThreshold")]
-    sell_threshold: f64,
-}
-
-// TODO: Maybe squash these into a single from that takes a serde_json::Value and returns a strategy
-impl From<RandomStrategyConfig> for RandomStrategy {
-    fn from(config: RandomStrategyConfig) -> Self {
-        RandomStrategy {
-            buy_threshold: config.buy_threshold,
-            sell_threshold: config.sell_threshold,
-            rng: rand::thread_rng(),
-        }
-    }
-}
-
-impl From<serde_json::Value> for RandomStrategyConfig {
-    fn from(value: serde_json::Value) -> Self {
-        // value = {"modelConfig": {"buyThreshold": 0.5, "sellThreshold": 0.5}}
-        let model_config = value["modelConfig"].clone();
-        serde_json::from_value(model_config).unwrap()
     }
 }

--- a/quantlib/src/util.rs
+++ b/quantlib/src/util.rs
@@ -1,3 +1,9 @@
+use serde::{Deserialize, Serialize};
+use serde_json;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
+
 use crate::oanda::objects::Settings;
 
 pub fn read_settings() -> Result<Settings, Box<dyn std::error::Error>> {
@@ -13,4 +19,24 @@ pub fn generate_timestamp() -> String {
 pub fn generate_timestamp_filename() -> String {
     let now = chrono::Utc::now();
     now.format("%Y-%m-%d_%H-%M-%S").to_string()
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct TradingConfig {
+    pub instruments: Vec<String>,
+    pub model: String,
+
+    #[serde(flatten)]
+    #[serde(rename = "modelConfig")]
+    pub model_config: serde_json::Value,
+}
+
+impl TradingConfig {
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, Box<dyn std::error::Error>> {
+        log::info!("Loading config from {:?}", path.as_ref());
+        let file = File::open(path)?;
+        let reader = BufReader::new(file);
+        let config = serde_json::from_reader(reader)?;
+        Ok(config)
+    }
 }

--- a/trading/src/main.rs
+++ b/trading/src/main.rs
@@ -1,20 +1,32 @@
-use quantlib::oanda::{PriceStream, FastPriceStream};
 use quantlib::models::{AlphaModel, PortfolioBuilder};
+use quantlib::oanda::{FastPriceStream, PriceStream};
+use quantlib::util::{read_settings, TradingConfig};
+use std::env;
 use std::error::Error;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let settings = quantlib::util::read_settings()?;
-    let instruments = vec!["EUR_USD".to_string()].to_vec();
-    let price_stream: FastPriceStream  = FastPriceStream::new(
-        instruments,
-        &settings.oanda,
-        1000,
-    );
-    
+    let mut args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: {} <config>", args[0]);
+        std::process::exit(1);
+    }
+
+    let settings = read_settings()?;
+    let config = TradingConfig::load(args.remove(1))?;
+    let instruments = config.instruments;
+    let price_stream: FastPriceStream = FastPriceStream::new(instruments, &settings.oanda, 1000);
+
     let mut portfolio_builder = PortfolioBuilder::new(&settings);
     portfolio_builder.update_positions().await?; // TODO: this should be done automatically by the portfolio builder
-    let mut ema = quantlib::models::ExponentialMovingAverage::new("EUR_USD".to_string(), 0.1, 0.2);
+
+    // Strategies must be "registered" here in order to be used
+    let mut strategy = match config.model.as_str() {
+        "random" => quantlib::models::RandomStrategy::from(
+            quantlib::models::RandomStrategyConfig::from(config.model_config),
+        ),
+        _ => panic!("Unknown model: {}", config.model),
+    };
 
     for item in price_stream {
         // Match on the item to see what kind of stream item it is, if it's a price, print it out, otherwise ignore it
@@ -24,7 +36,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     "[{}][PRICE] Bid: {:.5} Ask: {:.5}",
                     price.instrument, price.bid, price.ask
                 );
-                let signal = ema.tick(&price)?;
+                let signal = strategy.tick(&price)?;
                 match signal {
                     Some(signal) => {
                         println!(


### PR DESCRIPTION
Implemented config and de/serialization for two example strategies. Also made some unrelated changes to WeightedAverage strategy so that it uses an AlphaModels enum rather than dynamic dispatch. This feels somewhat awkward because strategies must be "registered" with the enum after being written, but this is the more Rust idiomatic implementation and allows for better performance and organization in other areas, like de/serialization.